### PR TITLE
Reaktiv updates

### DIFF
--- a/faq-manager.php
+++ b/faq-manager.php
@@ -64,11 +64,6 @@ class WP_FAQ_Manager
 		add_filter					( 'faq-caps',						array( $this, 'menu_filter'		), 10, 2	);
 		add_filter 					( 'plugin_action_links', 			array( $this, 'quick_link'		), 10, 2	);
 		add_filter					( 'post_class', 					array( $this, 'faq_post_class'	) 			);
-		add_shortcode				( 'faq',							array( $this, 'shortcode_main'	) 			);
-		add_shortcode				( 'faqlist',						array( $this, 'shortcode_list'	) 			);
-		add_shortcode				( 'faqcombo',						array( $this, 'shortcode_combo'	) 			);
-		add_shortcode				( 'faqtaxlist',						array( $this, 'shortcode_taxls'	) 			);
-
 	}
 
 	public function register_widgets() {

--- a/faq-shortcodes.php
+++ b/faq-shortcodes.php
@@ -11,17 +11,30 @@ class FAQ_Shortcodes {
 	}
 
 	/**
+	 * Get the current paged
+	 */
+	public function get_paged( $wp_query = null ) {
+		if( isset( $wp_query ) && isset( $wp_query->paged ) ) {
+			$paged = $wp_query->paged;
+		} else {
+			if( isset( $_GET['faq_page'] ) && $faq_page = absint( $_GET['faq_page'] ) ) {
+				$paged = $faq_page;
+			} else {
+				$paged = 1;
+			}
+		}
+
+		return $paged;
+	}
+
+	/**
 	 * Abstraction of the query that all shortcodes run
 	 *
 	 * @return WP_Query
 	 */
 	public function shortcode_query( $shortcode_args ) {
 		// set up $paged
-		if( isset( $_GET['faq_page'] ) && $faq_page = absint( $_GET['faq_page'] ) ) {
-			$paged = $faq_page;
-		} else {
-			$paged = 1;
-		}
+		$paged = $this->get_paged();
 
 		// clean up text
 		$faq_topic = sanitize_text_field( $shortcode_args['topic'] );
@@ -170,7 +183,7 @@ class FAQ_Shortcodes {
 				  'format'	=> '?faq_page=%#%',
 				  'type'	=> 'plain',
 				  'total'	=> $wp_query->max_num_pages,
-				  'current' => $wp_query->paged,
+				  'current' => $this->get_paged( $wp_query ),
 				  'end_size' => 2
 				));
 				$displayfaq .= '</p>';
@@ -237,27 +250,27 @@ class FAQ_Shortcodes {
 					'class'   => 'faqlist-question'
 				) );
 
-
 			endwhile;
 			$displayfaq .= '</ul>';
 
-				if (isset($faqopts['paginate'])) {
-					// pagination links
-					$displayfaq .= '<p class="faq-nav">';
-					$displayfaq .= paginate_links(array(
-					  'format'	=> '?faq_page=%#%',
-					  'type'	=> 'plain',
-					  'total'	=> $wp_query->max_num_pages,
-					  'current' => $wp_query->paged,
-					  'prev_text'	=> __('&laquo;'),
-						'next_text'	=> __('&raquo;'),
-						'end_size' => 2
-					));
-					$displayfaq .= '</p>';
-				// end pagination links
-				}
-				wp_reset_query();
-		$displayfaq .= '</div></div>';
+			if ( isset( $faqopts['paginate'] ) ) {
+				// pagination links
+				$displayfaq .= '<p class="faq-nav">';
+				$displayfaq .= paginate_links(array(
+				  'format'  	=> '?faq_page=%#%',
+				  'type'	    => 'plain',
+				  'total'   	=> $wp_query->max_num_pages,
+				  'current'   => $this->get_paged( $wp_query ),
+				  'prev_text'	=> __('&laquo;'),
+					'next_text'	=> __('&raquo;'),
+					'end_size'  => 2
+				));
+				$displayfaq .= '</p>';
+			// end pagination links
+			}
+			wp_reset_query();
+
+			$displayfaq .= '</div></div>';
 		endif;
 
 		do_action( 'load_wp_faqs', $context );

--- a/faq-shortcodes.php
+++ b/faq-shortcodes.php
@@ -110,10 +110,10 @@ class FAQ_Shortcodes {
 		), $atts));
 
 		$wp_query = $this->shortcode_query( array(
-			'topic'      => $faq_topic,
-			'tag'        => $faq_tag,
-			'id'         => $faq_id,
-			'limit'      => $limit,
+			'topic'      => sanitize_text_field( $faq_topic ),
+			'tag'        => sanitize_text_field( $faq_tag ),
+			'id'         => absint( $faq_id ),
+			'limit'      => intval( $limit ),
 			'pagination' => true
 		) );
 
@@ -202,10 +202,10 @@ class FAQ_Shortcodes {
 		), $atts));
 
 		$wp_query = $this->shortcode_query( array(
-			'topic'      => $faq_topic,
-			'tag'        => $faq_tag,
-			'id'         => $faq_id,
-			'limit'      => $limit,
+			'topic'      => sanitize_text_field( $faq_topic ),
+			'tag'        => sanitize_text_field( $faq_tag ),
+			'id'         => absint( $faq_id ),
+			'limit'      => intval( $limit ),
 			'pagination' => true
 		) );
 
@@ -281,9 +281,9 @@ class FAQ_Shortcodes {
 		), $atts));
 
 		$wp_query = $this->shortcode_query( array(
-			'topic' => $faq_topic,
-			'tag'   => $faq_tag,
-			'id'    => $faq_id,
+			'topic' => sanitize_text_field( $faq_topic ),
+			'tag'   => sanitize_text_field( $faq_tag ),
+			'id'    => absint( $faq_id ),
 			'limit' => -1
 		) );
 

--- a/faq-shortcodes.php
+++ b/faq-shortcodes.php
@@ -164,16 +164,14 @@ class FAQ_Shortcodes {
 			endwhile;
 
 			if (isset($faqopts['paginate'])) {
-				$old_link = trailingslashit(get_permalink());
-
 				// pagination links
 				$displayfaq .= '<p class="faq-nav">';
 				$displayfaq .= paginate_links(array(
-				  'base'	=> $old_link . '%_%',
 				  'format'	=> '?faq_page=%#%',
 				  'type'	=> 'plain',
 				  'total'	=> $wp_query->max_num_pages,
-				  'current' => $paged,
+				  'current' => $wp_query->paged,
+				  'end_size' => 2
 				));
 				$displayfaq .= '</p>';
 				// end pagination links
@@ -244,18 +242,16 @@ class FAQ_Shortcodes {
 			$displayfaq .= '</ul>';
 
 				if (isset($faqopts['paginate'])) {
-					$old_link = trailingslashit(get_permalink());
-
 					// pagination links
 					$displayfaq .= '<p class="faq-nav">';
 					$displayfaq .= paginate_links(array(
-						'base'		=> $old_link . '%_%',
-						'format'	=> '?faq_page=%#%',
-						'type'		=> 'plain',
-						'total'		=> $wp_query->max_num_pages,
-						'current'	=> $paged,
-						'prev_text'	=> __('&laquo;'),
+					  'format'	=> '?faq_page=%#%',
+					  'type'	=> 'plain',
+					  'total'	=> $wp_query->max_num_pages,
+					  'current' => $wp_query->paged,
+					  'prev_text'	=> __('&laquo;'),
 						'next_text'	=> __('&raquo;'),
+						'end_size' => 2
 					));
 					$displayfaq .= '</p>';
 				// end pagination links

--- a/faq-shortcodes.php
+++ b/faq-shortcodes.php
@@ -24,12 +24,12 @@ class FAQ_Shortcodes {
 		}
 
 		// clean up text
-		$faq_topic	= preg_replace('~&#x0*([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $shortcode_args['topic']);
-		$faq_tag = preg_replace('~&#x0*([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $shortcode_args['tag']);
+		$faq_topic = sanitize_text_field( $shortcode_args['topic'] );
+		$faq_tag = sanitize_text_field( $shortcode_args['tag'] );
 
 		// FAQ query
 		$args = array (
-			'p'				  => '' . $shortcode_args['id'] . '',
+			'p'				  => '' . absint( $shortcode_args['id'] ) . '',
 			'faq-topic'	=> '' . $faq_topic . '',
 			'faq-tags'	=> '' . $faq_tag . '',
 			'post_type'	=> 'question',
@@ -39,7 +39,7 @@ class FAQ_Shortcodes {
 
 		// handle optional limit
 		if( isset( $shortcode_args['limit'] ) ) {
-			$args['posts_per_page'] =	'' . $shortcode_args['limit'] . '';
+			$args['posts_per_page'] =	'' . intval( $shortcode_args['limit'] ) . '';
 		}
 
 		// handle optional pagination

--- a/faq-shortcodes.php
+++ b/faq-shortcodes.php
@@ -63,6 +63,8 @@ class FAQ_Shortcodes {
 	function format_faq_title( $title_data ) {
 		$html_title = '';
 
+		$title_data = array_map( 'sanitize_text_field' , $title_data );
+
 		switch( $title_data['context'] ) {
 			case 'list':
 				$html_title = '<li class="' . $title_data['class'] . '"><a href="' . $title_data['link'] . '" title="Permanent link to ' . $title_data['title'] . '" >' . $title_data['title'] . '</a></li>';


### PR DESCRIPTION
Addresses the following:

* deprecated notices appearing in shortcode displays
* various missing index notices on both front end and admin
* pagination no longer working
* shortcode function calls still present on main file
* missing sanitization / escaping on variables in the new abstracted query logic, title formatting, and a few other places

2 notes:

* For the various missing index notices- I only saw 1... did you see more?
* For the deprecated notices, that was a place where I just used code you used elsewhere. I replaced the custom `preg_replace` with the WordPress `sanitize_text_field`.. was there any reason you went with the custom `preg_replace`? 